### PR TITLE
Fix "Unable to load main class"

### DIFF
--- a/src/main/java/io/github/miniplaceholders/expansion/spark/CPUProcessPlaceholder.java
+++ b/src/main/java/io/github/miniplaceholders/expansion/spark/CPUProcessPlaceholder.java
@@ -1,4 +1,4 @@
-package io.github.miniplaceholders.expansion.spark.common;
+package io.github.miniplaceholders.expansion.spark;
 
 import io.github.miniplaceholders.api.resolver.GlobalTagResolver;
 import me.lucko.spark.api.Spark;
@@ -11,10 +11,10 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 
-record CPUSystemPlaceholder(Spark spark) implements GlobalTagResolver {
+record CPUProcessPlaceholder(Spark spark) implements GlobalTagResolver {
     @Override
     public Tag tag(ArgumentQueue argumentQueue, Context context) {
-        final DoubleStatistic<StatisticWindow.CpuUsage> cpuUsage = spark.cpuSystem();
+        final DoubleStatistic<StatisticWindow.CpuUsage> cpuUsage = spark.cpuProcess();
         if (!argumentQueue.hasNext()) {
             final double[] usage = cpuUsage.poll();
             final Component component = MiniMessage.miniMessage().deserialize(

--- a/src/main/java/io/github/miniplaceholders/expansion/spark/CPUSystemPlaceholder.java
+++ b/src/main/java/io/github/miniplaceholders/expansion/spark/CPUSystemPlaceholder.java
@@ -1,4 +1,4 @@
-package io.github.miniplaceholders.expansion.spark.common;
+package io.github.miniplaceholders.expansion.spark;
 
 import io.github.miniplaceholders.api.resolver.GlobalTagResolver;
 import me.lucko.spark.api.Spark;
@@ -11,10 +11,10 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 
-record CPUProcessPlaceholder(Spark spark) implements GlobalTagResolver {
+record CPUSystemPlaceholder(Spark spark) implements GlobalTagResolver {
     @Override
     public Tag tag(ArgumentQueue argumentQueue, Context context) {
-        final DoubleStatistic<StatisticWindow.CpuUsage> cpuUsage = spark.cpuProcess();
+        final DoubleStatistic<StatisticWindow.CpuUsage> cpuUsage = spark.cpuSystem();
         if (!argumentQueue.hasNext()) {
             final double[] usage = cpuUsage.poll();
             final Component component = MiniMessage.miniMessage().deserialize(

--- a/src/main/java/io/github/miniplaceholders/expansion/spark/MSPTPlaceholder.java
+++ b/src/main/java/io/github/miniplaceholders/expansion/spark/MSPTPlaceholder.java
@@ -1,4 +1,4 @@
-package io.github.miniplaceholders.expansion.spark.common;
+package io.github.miniplaceholders.expansion.spark;
 
 import io.github.miniplaceholders.api.resolver.GlobalTagResolver;
 import me.lucko.spark.api.Spark;

--- a/src/main/java/io/github/miniplaceholders/expansion/spark/SparkExpansionProvider.java
+++ b/src/main/java/io/github/miniplaceholders/expansion/spark/SparkExpansionProvider.java
@@ -1,4 +1,4 @@
-package io.github.miniplaceholders.expansion.spark.common;
+package io.github.miniplaceholders.expansion.spark;
 
 import io.github.miniplaceholders.api.Expansion;
 import io.github.miniplaceholders.api.provider.ExpansionProvider;

--- a/src/main/java/io/github/miniplaceholders/expansion/spark/TPSPlaceholder.java
+++ b/src/main/java/io/github/miniplaceholders/expansion/spark/TPSPlaceholder.java
@@ -1,4 +1,4 @@
-package io.github.miniplaceholders.expansion.spark.common;
+package io.github.miniplaceholders.expansion.spark;
 
 import io.github.miniplaceholders.api.resolver.GlobalTagResolver;
 import me.lucko.spark.api.Spark;

--- a/src/main/resources/expansion-provider.properties
+++ b/src/main/resources/expansion-provider.properties
@@ -1,1 +1,1 @@
-provider-class=io.miniplaceholders.expansion.spark.SparkExpansionProvider
+provider-class=io.github.miniplaceholders.expansion.spark.SparkExpansionProvider


### PR DESCRIPTION
This corrects the `provider-class` property defined in the `expansion-provider.properties` file, which prevented the expansion from being loaded.

Also moved all the classes out from the common package to be consistent with other similar expansions.